### PR TITLE
Implement Statement support on DremioFlightProducer

### DIFF
--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
@@ -32,6 +32,7 @@ import static org.apache.arrow.flight.sql.impl.FlightSql.CommandPreparedStatemen
 import static org.apache.arrow.flight.sql.impl.FlightSql.CommandPreparedStatementUpdate;
 import static org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementQuery;
 import static org.apache.arrow.flight.sql.impl.FlightSql.CommandStatementUpdate;
+import static org.apache.arrow.flight.sql.impl.FlightSql.TicketStatementQuery;
 
 import java.util.concurrent.TimeUnit;
 
@@ -265,8 +266,8 @@ public class DremioFlightProducer implements FlightSqlProducer {
 
     flightPreparedStatementCache.put(flightPreparedStatement.getServerHandle(), flightPreparedStatement);
 
-    FlightSql.TicketStatementQuery ticket =
-      FlightSql.TicketStatementQuery.newBuilder()
+    TicketStatementQuery ticket =
+      TicketStatementQuery.newBuilder()
         .setStatementHandle(flightPreparedStatement.getServerHandle().toByteString())
         .build();
 
@@ -283,7 +284,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void getStreamStatement(FlightSql.TicketStatementQuery commandStatementQuery,
+  public void getStreamStatement(TicketStatementQuery commandStatementQuery,
                                  CallContext callContext,
                                  ServerStreamListener serverStreamListener) {
     try {
@@ -492,7 +493,8 @@ public class DremioFlightProducer implements FlightSqlProducer {
       command.is(CommandGetCatalogs.class) || command.is(CommandGetSchemas.class) ||
       command.is(CommandGetTables.class) || command.is(CommandGetTableTypes.class) ||
       command.is(CommandGetSqlInfo.class) || command.is(CommandGetPrimaryKeys.class) ||
-      command.is(CommandGetExportedKeys.class) || command.is(CommandGetImportedKeys.class);
+      command.is(CommandGetExportedKeys.class) || command.is(CommandGetImportedKeys.class) ||
+      command.is(TicketStatementQuery.class);
   }
 
   private boolean isFlightSqlCommand(byte[] bytes) {

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
@@ -55,7 +55,6 @@ import org.apache.arrow.flight.SchemaResult;
 import org.apache.arrow.flight.Ticket;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
 import org.apache.arrow.flight.sql.FlightSqlUtils;
-import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -286,6 +285,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
   @Override
   public void getStreamStatement(TicketStatementQuery commandStatementQuery,
                                  CallContext callContext,
+                                 Ticket ticket,
                                  ServerStreamListener serverStreamListener) {
     try {
       final UserProtos.PreparedStatementHandle preparedStatementHandle =

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
@@ -341,7 +341,9 @@ public class DremioFlightProducer implements FlightSqlProducer {
   public FlightInfo getFlightInfoCatalogs(
     CommandGetCatalogs commandGetCatalogs, CallContext callContext,
     FlightDescriptor flightDescriptor) {
-    return getFlightInfoForFlightSqlCommands(commandGetCatalogs, flightDescriptor, getSchemaCatalogs().getSchema());
+
+    final Schema catalogsSchema = Schemas.GET_CATALOGS_SCHEMA;
+    return getFlightInfoForFlightSqlCommands(commandGetCatalogs, flightDescriptor, catalogsSchema);
   }
 
   @Override
@@ -356,7 +358,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
   public FlightInfo getFlightInfoSchemas(CommandGetSchemas commandGetSchemas,
                                          CallContext callContext,
                                          FlightDescriptor flightDescriptor) {
-    final Schema schema = getSchemaSchemas().getSchema();
+    final Schema schema = Schemas.GET_SCHEMAS_SCHEMA;
     return getFlightInfoForFlightSqlCommands(commandGetSchemas, flightDescriptor, schema);
   }
 
@@ -378,7 +380,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
   public FlightInfo getFlightInfoTables(CommandGetTables commandGetTables,
                                         CallContext callContext,
                                         FlightDescriptor flightDescriptor) {
-    final Schema schema = getSchemaTables().getSchema();
+    final Schema schema = Schemas.GET_TABLES_SCHEMA;
 
     return getFlightInfoForFlightSqlCommands(commandGetTables, flightDescriptor, schema);
   }
@@ -397,7 +399,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
   public FlightInfo getFlightInfoTableTypes(
     CommandGetTableTypes commandGetTableTypes, CallContext callContext,
     FlightDescriptor flightDescriptor) {
-    final Schema schema = getSchemaTableTypes().getSchema();
+    final Schema schema = Schemas.GET_TABLE_TYPES_SCHEMA;
 
     return getFlightInfoForFlightSqlCommands(commandGetTableTypes, flightDescriptor, schema);
   }

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
@@ -283,13 +283,13 @@ public class DremioFlightProducer implements FlightSqlProducer {
   }
 
   @Override
-  public void getStreamStatement(TicketStatementQuery commandStatementQuery,
+  public void getStreamStatement(TicketStatementQuery ticketStatementQuery,
                                  CallContext callContext,
                                  Ticket ticket,
                                  ServerStreamListener serverStreamListener) {
     try {
       final UserProtos.PreparedStatementHandle preparedStatementHandle =
-        UserProtos.PreparedStatementHandle.parseFrom(commandStatementQuery.getStatementHandle());
+        UserProtos.PreparedStatementHandle.parseFrom(ticketStatementQuery.getStatementHandle());
 
       runPreparedStatement(callContext, serverStreamListener, preparedStatementHandle);
     } catch (InvalidProtocolBufferException e) {
@@ -341,7 +341,6 @@ public class DremioFlightProducer implements FlightSqlProducer {
   public FlightInfo getFlightInfoCatalogs(
     CommandGetCatalogs commandGetCatalogs, CallContext callContext,
     FlightDescriptor flightDescriptor) {
-
     final Schema catalogsSchema = Schemas.GET_CATALOGS_SCHEMA;
     return getFlightInfoForFlightSqlCommands(commandGetCatalogs, flightDescriptor, catalogsSchema);
   }

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/DremioFlightProducer.java
@@ -225,7 +225,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
     ActionCreatePreparedStatementRequest actionCreatePreparedStatementRequest,
     CallContext callContext,
     StreamListener<Result> streamListener) {
-    String query = actionCreatePreparedStatementRequest.getQuery();
+    final String query = actionCreatePreparedStatementRequest.getQuery();
 
     final UserSession session = getUserSessionFromCallContext(callContext);
     final FlightPreparedStatement flightPreparedStatement = flightWorkManager
@@ -266,12 +266,12 @@ public class DremioFlightProducer implements FlightSqlProducer {
 
     flightPreparedStatementCache.put(flightPreparedStatement.getServerHandle(), flightPreparedStatement);
 
-    TicketStatementQuery ticket =
+    final TicketStatementQuery ticket =
       TicketStatementQuery.newBuilder()
         .setStatementHandle(flightPreparedStatement.getServerHandle().toByteString())
         .build();
 
-    Schema schema = flightPreparedStatement.getSchema();
+    final Schema schema = flightPreparedStatement.getSchema();
     return getFlightInfoForFlightSqlCommands(ticket, flightDescriptor, schema);
   }
 
@@ -279,7 +279,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
   public SchemaResult getSchemaStatement(
     CommandStatementQuery commandStatementQuery,
     CallContext callContext, FlightDescriptor flightDescriptor) {
-    FlightInfo info = this.getFlightInfo(callContext, flightDescriptor);
+    final FlightInfo info = this.getFlightInfo(callContext, flightDescriptor);
     return new SchemaResult(info.getSchema());
   }
 
@@ -288,7 +288,7 @@ public class DremioFlightProducer implements FlightSqlProducer {
                                  CallContext callContext,
                                  ServerStreamListener serverStreamListener) {
     try {
-      UserProtos.PreparedStatementHandle preparedStatementHandle =
+      final UserProtos.PreparedStatementHandle preparedStatementHandle =
         UserProtos.PreparedStatementHandle.parseFrom(commandStatementQuery.getStatementHandle());
 
       runPreparedStatement(callContext, serverStreamListener, preparedStatementHandle);

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightPreparedStatement.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightPreparedStatement.java
@@ -26,7 +26,6 @@ import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import com.dremio.exec.proto.UserProtos;
-import com.dremio.service.flight.TicketContent.PreparedStatementTicket;
 import com.dremio.service.flight.protector.CancellableUserResponseHandler;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightPreparedStatement.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightPreparedStatement.java
@@ -57,7 +57,7 @@ public class FlightPreparedStatement {
     final UserProtos.CreatePreparedStatementArrowResp createPreparedStatementResp = responseHandler.get();
     final Schema schema = buildSchema(createPreparedStatementResp.getPreparedStatement().getArrowSchema());
 
-    UserProtos.PreparedStatementHandle preparedStatementHandle = getServerHandle();
+    final UserProtos.PreparedStatementHandle preparedStatementHandle = getServerHandle();
 
     final FlightSql.CommandPreparedStatementQuery command = FlightSql.CommandPreparedStatementQuery.newBuilder()
       .setPreparedStatementHandle(preparedStatementHandle.toByteString())

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightWorkManager.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightWorkManager.java
@@ -85,6 +85,14 @@ public class FlightWorkManager {
     return createPreparedStatement(query, isRequestCancelled, userSession);
   }
 
+  /**
+   * Submits a CREATE_PREPARED_STATEMENT job to a worker and returns a FlightPreparedStatement.
+   *
+   * @param query               The query which will be executed.
+   * @param isRequestCancelled  A supplier to evaluate if the client cancelled the request.
+   * @param userSession         The session for the user which made the request.
+   * @return A FlightPreparedStatement which consumes the result of the job.
+   */
   public FlightPreparedStatement createPreparedStatement(String query,
                                                          Supplier<Boolean> isRequestCancelled,
                                                          UserSession userSession) {

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightWorkManager.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightWorkManager.java
@@ -82,7 +82,12 @@ public class FlightWorkManager {
                                                          Supplier<Boolean> isRequestCancelled,
                                                          UserSession userSession) {
     final String query = getQuery(flightDescriptor);
+    return createPreparedStatement(query, isRequestCancelled, userSession);
+  }
 
+  public FlightPreparedStatement createPreparedStatement(String query,
+                                                         Supplier<Boolean> isRequestCancelled,
+                                                         UserSession userSession) {
     final UserProtos.CreatePreparedStatementArrowReq createPreparedStatementReq =
       UserProtos.CreatePreparedStatementArrowReq.newBuilder()
         .setSqlQuery(query)
@@ -100,7 +105,7 @@ public class FlightWorkManager {
     workerProvider.get().submitWork(prepareExternalId, userSession, createPreparedStatementResponseHandler,
       userRequest, TerminationListenerRegistry.NOOP);
 
-    return new FlightPreparedStatement(flightDescriptor, query, createPreparedStatementResponseHandler);
+    return new FlightPreparedStatement(query, createPreparedStatementResponseHandler);
   }
 
   public void runPreparedStatement(UserProtos.PreparedStatementHandle preparedStatementHandle,

--- a/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightWorkManager.java
+++ b/services/arrow-flight/src/main/java/com/dremio/service/flight/impl/FlightWorkManager.java
@@ -28,8 +28,8 @@ import javax.inject.Provider;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightProducer;
-import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.flight.sql.FlightSqlProducer;
+import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -50,7 +50,6 @@ import com.dremio.service.flight.impl.RunQueryResponseHandler.BackpressureHandli
 import com.dremio.service.flight.impl.RunQueryResponseHandler.BasicResponseHandler;
 import com.dremio.service.flight.protector.CancellableUserResponseHandler;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 
 /**
  * Manager class for submitting jobs to a UserWorker and optionally returning the appropriate Dremio Flight

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightServer.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.dremio.service.flight;
 
 import static org.junit.Assert.assertEquals;

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightServer.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.dremio.service.flight;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.ArrayList;

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
@@ -26,6 +26,9 @@ import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/**
+ * Base class for Flight SQL query execution tests.
+ */
 @RunWith(Parameterized.class)
 public abstract class AbstractTestFlightSqlServer extends AbstractTestFlightServer {
 
@@ -67,8 +70,9 @@ public abstract class AbstractTestFlightSqlServer extends AbstractTestFlightServ
         return executeStatement(query);
       case PREPARED_STATEMENT:
         return executePreparedStatement(query);
+      default:
+        throw new IllegalStateException();
     }
 
-    throw new IllegalStateException();
   }
 }

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
@@ -16,7 +16,11 @@
 
 package com.dremio.service.flight;
 
+import static java.util.Arrays.asList;
+
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.Collections;
@@ -30,6 +34,8 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import com.dremio.service.catalog.TableType;
 import com.dremio.exec.expr.fn.impl.RegexpUtil;
@@ -38,190 +44,43 @@ import com.dremio.exec.proto.UserProtos;
 
 import com.google.common.collect.ImmutableList;
 
+@RunWith(Parameterized.class)
 public abstract class AbstractTestFlightSqlServer extends AbstractTestFlightServer {
 
+  private final ExecutionMode executionMode;
+
+  enum ExecutionMode {
+    STATEMENT,
+    PREPARED_STATEMENT
+  }
+
+  @Parameterized.Parameters(name = "ExecutionMode: {0}")
+  public static Collection<ExecutionMode> parameters() {
+    return asList(ExecutionMode.STATEMENT, ExecutionMode.PREPARED_STATEMENT);
+  }
+
+  public AbstractTestFlightSqlServer(ExecutionMode executionMode) {
+    this.executionMode = executionMode;
+  }
+
+  private FlightInfo executeStatement(String query) {
+    FlightSqlClient client = getFlightClientWrapper().getSqlClient();
+    return client.execute(query, getCallOptions());
+  }
+
+  private FlightInfo executePreparedStatement(String query) throws SQLException {
+    FlightSqlClient client = getFlightClientWrapper().getSqlClient();
+    FlightSqlClient.PreparedStatement preparedStatement = client.prepare(query, getCallOptions());
+    return preparedStatement.execute(getCallOptions());
+  }
+
   @Override
-  public FlightInfo getFlightInfo(String query) throws SQLException {
-    final FlightClientUtils.FlightClientWrapper clientWrapper = getFlightClientWrapper();
-    return clientWrapper.getSqlClient().execute(query, getCallOptions());
-  }
-
-  @Test
-  public void testGetCatalogs() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    CallOption[] callOptions = getCallOptions();
-
-    FlightInfo flightInfo = flightSqlClient.getCatalogs(callOptions);
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), callOptions)) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-      Assert.assertEquals(1, root.getRowCount());
-
-      String catalogName = ((VarCharVector) root.getVector("catalog_name")).getObject(0).toString();
-      Assert.assertEquals("DREMIO", catalogName);
+  public FlightInfo getFlightInfo(String query) throws SQLException{
+    switch (executionMode) {
+      case STATEMENT: return executeStatement(query);
+      case PREPARED_STATEMENT: return executePreparedStatement(query);
     }
-  }
 
-  @Test
-  public void testGetTablesWithoutFiltering() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
-      null, false, getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Assert.assertEquals(root.getRowCount(), 28);
-    }
-  }
-
-  @Test
-  public void testGetTablesFilteringByCatalogPattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables("DREMIO", null, null,
-      null, false, getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
-      getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Assert.assertEquals(root.getRowCount(), 28);
-    }
-  }
-
-  @Test
-  public void testGetTablesFilteringBySchemaPattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, "INFORMATION_SCHEMA",
-      null, null, false, getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
-      getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Assert.assertEquals(root.getRowCount(), 5);
-    }
-  }
-
-  @Test
-  public void testGetTablesFilteringByTablePattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, "COLUMNS",
-      null, false, getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
-      getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Assert.assertEquals(root.getRowCount(), 1);
-    }
-  }
-
-  @Test
-  public void testGetTablesFilteringByTableTypePattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
-      Collections.singletonList("SYSTEM_TABLE"), false, getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
-      getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Assert.assertEquals(root.getRowCount(), 28);
-    }
-  }
-
-  @Test
-  public void testGetTablesFilteringByMultiTableTypes() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
-      ImmutableList.of("TABLE", "VIEW"), false, getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
-      getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Assert.assertEquals(root.getRowCount(), 0);
-    }
-  }
-
-  @Test
-  public void testGetTablesTypes() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTableTypes(getCallOptions());
-    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      final ImmutableList<TableType> tableTypes = ImmutableList.of(TableType.TABLE, TableType.SYSTEM_TABLE, TableType.VIEW);
-      final int counter = tableTypes.size();
-
-      final IntStream range = IntStream.range(0, counter);
-
-      Assert.assertEquals(root.getRowCount(), counter);
-      range.forEach(i -> {
-        Assert.assertEquals(root.getVector(0).getObject(i).toString(), tableTypes.get(i).toString());
-      });
-    }
-  }
-
-  private void testGetSchemas(String catalog, String schemaPattern, boolean expectNonEmptyResult) throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getSchemas(catalog, schemaPattern, getCallOptions());
-    try (
-      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
-      Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
-
-      Predicate<String> catalogNamePredicate = MetadataProviderConditions.getCatalogNamePredicate(
-        catalog != null ? UserProtos.LikeFilter.newBuilder().setPattern(catalog).build() : null);
-      Pattern schemaFilterPattern = schemaPattern != null ? Pattern.compile(RegexpUtil.sqlToRegexLike(schemaPattern)) :
-        Pattern.compile(".*");
-
-      VarCharVector catalogNameVector = (VarCharVector) root.getVector("catalog_name");
-      VarCharVector schemaNameVector = (VarCharVector) root.getVector("schema_name");
-
-      for (int i = 0; i < root.getRowCount(); i++) {
-        String catalogName = catalogNameVector.getObject(i).toString();
-        String schemaName = schemaNameVector.getObject(i).toString();
-
-        Assert.assertTrue(catalogNamePredicate.test(catalogName));
-        Assert.assertTrue(schemaFilterPattern.matcher(schemaName).matches());
-      }
-
-      if (expectNonEmptyResult) {
-        Assert.assertTrue(root.getRowCount() > 0);
-      }
-    }
-  }
-
-  @Test
-  public void testGetSchemasWithNoFilter() throws Exception {
-    testGetSchemas(null, null, true);
-  }
-
-  @Test
-  public void testGetSchemasWithBothFilters() throws Exception {
-    testGetSchemas("DREMIO", "INFORMATION_SCHEMA", true);
-  }
-
-  @Test
-  public void testGetSchemasWithCatalog() throws Exception {
-    testGetSchemas("DREMIO", null, true);
-  }
-
-  @Test
-  public void testGetSchemasWithSchemaFilterPattern() throws Exception {
-    testGetSchemas(null, "sys", true);
-  }
-
-  @Test
-  public void testGetSchemasWithNonMatchingSchemaFilter() throws Exception {
-    testGetSchemas(null, "NON_EXISTING_SCHEMA", false);
-  }
-
-  @Test
-  public void testGetSchemasWithNonMatchingCatalog() throws Exception {
-    testGetSchemas("NON_EXISTING_CATALOG", null, false);
+    throw new IllegalStateException();
   }
 }

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
@@ -64,13 +64,13 @@ public abstract class AbstractTestFlightSqlServer extends AbstractTestFlightServ
   }
 
   private FlightInfo executeStatement(String query) {
-    FlightSqlClient client = getFlightClientWrapper().getSqlClient();
+    final FlightSqlClient client = getFlightClientWrapper().getSqlClient();
     return client.execute(query, getCallOptions());
   }
 
   private FlightInfo executePreparedStatement(String query) throws SQLException {
-    FlightSqlClient client = getFlightClientWrapper().getSqlClient();
-    FlightSqlClient.PreparedStatement preparedStatement = client.prepare(query, getCallOptions());
+    final FlightSqlClient client = getFlightClientWrapper().getSqlClient();
+    final FlightSqlClient.PreparedStatement preparedStatement = client.prepare(query, getCallOptions());
     return preparedStatement.execute(getCallOptions());
   }
 

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.dremio.service.flight;
 
 import static java.util.Arrays.asList;

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServer.java
@@ -43,11 +43,7 @@ public abstract class AbstractTestFlightSqlServer extends AbstractTestFlightServ
   @Override
   public FlightInfo getFlightInfo(String query) throws SQLException {
     final FlightClientUtils.FlightClientWrapper clientWrapper = getFlightClientWrapper();
-
-    final FlightSqlClient.PreparedStatement preparedStatement =
-      clientWrapper.getSqlClient().prepare(query, getCallOptions());
-
-    return preparedStatement.execute(getCallOptions());
+    return clientWrapper.getSqlClient().execute(query, getCallOptions());
   }
 
   @Test

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServerCatalogMethods.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServerCatalogMethods.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2017-2019 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dremio.service.flight;
+
+import java.util.Collections;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
+
+import org.apache.arrow.flight.CallOption;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightStream;
+import org.apache.arrow.flight.sql.FlightSqlClient;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.dremio.exec.expr.fn.impl.RegexpUtil;
+import com.dremio.exec.planner.sql.handlers.commands.MetadataProviderConditions;
+import com.dremio.exec.proto.UserProtos;
+import com.dremio.service.catalog.TableType;
+import com.google.common.collect.ImmutableList;
+
+public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlightQueryTest {
+
+  abstract CallOption[] getCallOptions();
+
+  @Test
+  public void testGetCatalogs() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    CallOption[] callOptions = getCallOptions();
+
+    FlightInfo flightInfo = flightSqlClient.getCatalogs(callOptions);
+    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), callOptions)) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+      Assert.assertEquals(1, root.getRowCount());
+
+      String catalogName = ((VarCharVector) root.getVector("catalog_name")).getObject(0).toString();
+      Assert.assertEquals("DREMIO", catalogName);
+    }
+  }
+
+  @Test
+  public void testGetTablesWithoutFiltering() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
+      null, false, getCallOptions());
+    try (
+      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Assert.assertEquals(root.getRowCount(), 28);
+    }
+  }
+
+  @Test
+  public void testGetTablesFilteringByCatalogPattern() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTables("DREMIO", null, null,
+      null, false, getCallOptions());
+    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
+      getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Assert.assertEquals(root.getRowCount(), 28);
+    }
+  }
+
+  @Test
+  public void testGetTablesFilteringBySchemaPattern() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTables(null, "INFORMATION_SCHEMA",
+      null, null, false, getCallOptions());
+    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
+      getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Assert.assertEquals(root.getRowCount(), 5);
+    }
+  }
+
+  @Test
+  public void testGetTablesFilteringByTablePattern() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTables(null, null, "COLUMNS",
+      null, false, getCallOptions());
+    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
+      getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Assert.assertEquals(root.getRowCount(), 1);
+    }
+  }
+
+  @Test
+  public void testGetTablesFilteringByTableTypePattern() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
+      Collections.singletonList("SYSTEM_TABLE"), false, getCallOptions());
+    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
+      getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Assert.assertEquals(root.getRowCount(), 28);
+    }
+  }
+
+  @Test
+  public void testGetTablesFilteringByMultiTableTypes() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
+      ImmutableList.of("TABLE", "VIEW"), false, getCallOptions());
+    try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
+      getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Assert.assertEquals(root.getRowCount(), 0);
+    }
+  }
+
+  @Test
+  public void testGetTablesTypes() throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getTableTypes(getCallOptions());
+    try (
+      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      final ImmutableList<TableType> tableTypes =
+        ImmutableList.of(TableType.TABLE, TableType.SYSTEM_TABLE, TableType.VIEW);
+      final int counter = tableTypes.size();
+
+      final IntStream range = IntStream.range(0, counter);
+
+      Assert.assertEquals(root.getRowCount(), counter);
+      range.forEach(i -> {
+        Assert.assertEquals(root.getVector(0).getObject(i).toString(), tableTypes.get(i).toString());
+      });
+    }
+  }
+
+  private void testGetSchemas(String catalog, String schemaPattern, boolean expectNonEmptyResult) throws Exception {
+    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    FlightInfo flightInfo = flightSqlClient.getSchemas(catalog, schemaPattern, getCallOptions());
+    try (
+      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
+      Assert.assertTrue(stream.next());
+      VectorSchemaRoot root = stream.getRoot();
+
+      Predicate<String> catalogNamePredicate = MetadataProviderConditions.getCatalogNamePredicate(
+        catalog != null ? UserProtos.LikeFilter.newBuilder().setPattern(catalog).build() : null);
+      Pattern schemaFilterPattern = schemaPattern != null ? Pattern.compile(RegexpUtil.sqlToRegexLike(schemaPattern)) :
+        Pattern.compile(".*");
+
+      VarCharVector catalogNameVector = (VarCharVector) root.getVector("catalog_name");
+      VarCharVector schemaNameVector = (VarCharVector) root.getVector("schema_name");
+
+      for (int i = 0; i < root.getRowCount(); i++) {
+        String catalogName = catalogNameVector.getObject(i).toString();
+        String schemaName = schemaNameVector.getObject(i).toString();
+
+        Assert.assertTrue(catalogNamePredicate.test(catalogName));
+        Assert.assertTrue(schemaFilterPattern.matcher(schemaName).matches());
+      }
+
+      if (expectNonEmptyResult) {
+        Assert.assertTrue(root.getRowCount() > 0);
+      }
+    }
+  }
+
+  @Test
+  public void testGetSchemasWithNoFilter() throws Exception {
+    testGetSchemas(null, null, true);
+  }
+
+  @Test
+  public void testGetSchemasWithBothFilters() throws Exception {
+    testGetSchemas("DREMIO", "INFORMATION_SCHEMA", true);
+  }
+
+  @Test
+  public void testGetSchemasWithCatalog() throws Exception {
+    testGetSchemas("DREMIO", null, true);
+  }
+
+  @Test
+  public void testGetSchemasWithSchemaFilterPattern() throws Exception {
+    testGetSchemas(null, "sys", true);
+  }
+
+  @Test
+  public void testGetSchemasWithNonMatchingSchemaFilter() throws Exception {
+    testGetSchemas(null, "NON_EXISTING_SCHEMA", false);
+  }
+
+  @Test
+  public void testGetSchemasWithNonMatchingCatalog() throws Exception {
+    testGetSchemas("NON_EXISTING_CATALOG", null, false);
+  }
+}

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServerCatalogMethods.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServerCatalogMethods.java
@@ -37,6 +37,9 @@ import com.dremio.exec.proto.UserProtos;
 import com.dremio.service.catalog.TableType;
 import com.google.common.collect.ImmutableList;
 
+/**
+ * Base class for Flight SQL catalog methods tests.
+ */
 public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlightQueryTest {
 
   private FlightSqlClient flightSqlClient;

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServerCatalogMethods.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/AbstractTestFlightSqlServerCatalogMethods.java
@@ -42,29 +42,29 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetCatalogs() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    CallOption[] callOptions = getCallOptions();
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final CallOption[] callOptions = getCallOptions();
 
-    FlightInfo flightInfo = flightSqlClient.getCatalogs(callOptions);
+    final FlightInfo flightInfo = flightSqlClient.getCatalogs(callOptions);
     try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), callOptions)) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
       Assert.assertEquals(1, root.getRowCount());
 
-      String catalogName = ((VarCharVector) root.getVector("catalog_name")).getObject(0).toString();
+      final String catalogName = ((VarCharVector) root.getVector("catalog_name")).getObject(0).toString();
       Assert.assertEquals("DREMIO", catalogName);
     }
   }
 
   @Test
   public void testGetTablesWithoutFiltering() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
       null, false, getCallOptions());
     try (
-      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
+      final FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       Assert.assertEquals(root.getRowCount(), 28);
     }
@@ -72,13 +72,13 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetTablesFilteringByCatalogPattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables("DREMIO", null, null,
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTables("DREMIO", null, null,
       null, false, getCallOptions());
     try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
       getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       Assert.assertEquals(root.getRowCount(), 28);
     }
@@ -86,13 +86,13 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetTablesFilteringBySchemaPattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, "INFORMATION_SCHEMA",
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTables(null, "INFORMATION_SCHEMA",
       null, null, false, getCallOptions());
     try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
       getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       Assert.assertEquals(root.getRowCount(), 5);
     }
@@ -100,13 +100,13 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetTablesFilteringByTablePattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, "COLUMNS",
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTables(null, null, "COLUMNS",
       null, false, getCallOptions());
     try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
       getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       Assert.assertEquals(root.getRowCount(), 1);
     }
@@ -114,13 +114,13 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetTablesFilteringByTableTypePattern() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
       Collections.singletonList("SYSTEM_TABLE"), false, getCallOptions());
     try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
       getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       Assert.assertEquals(root.getRowCount(), 28);
     }
@@ -128,13 +128,13 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetTablesFilteringByMultiTableTypes() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTables(null, null, null,
       ImmutableList.of("TABLE", "VIEW"), false, getCallOptions());
     try (FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(),
       getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       Assert.assertEquals(root.getRowCount(), 0);
     }
@@ -142,12 +142,12 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
 
   @Test
   public void testGetTablesTypes() throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getTableTypes(getCallOptions());
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getTableTypes(getCallOptions());
     try (
-      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
+      final FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
       final ImmutableList<TableType> tableTypes =
         ImmutableList.of(TableType.TABLE, TableType.SYSTEM_TABLE, TableType.VIEW);
@@ -163,24 +163,24 @@ public abstract class AbstractTestFlightSqlServerCatalogMethods extends BaseFlig
   }
 
   private void testGetSchemas(String catalog, String schemaPattern, boolean expectNonEmptyResult) throws Exception {
-    FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
-    FlightInfo flightInfo = flightSqlClient.getSchemas(catalog, schemaPattern, getCallOptions());
+    final FlightSqlClient flightSqlClient = getFlightClientWrapper().getSqlClient();
+    final FlightInfo flightInfo = flightSqlClient.getSchemas(catalog, schemaPattern, getCallOptions());
     try (
-      FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
+      final FlightStream stream = flightSqlClient.getStream(flightInfo.getEndpoints().get(0).getTicket(), getCallOptions())) {
       Assert.assertTrue(stream.next());
-      VectorSchemaRoot root = stream.getRoot();
+      final VectorSchemaRoot root = stream.getRoot();
 
-      Predicate<String> catalogNamePredicate = MetadataProviderConditions.getCatalogNamePredicate(
+      final Predicate<String> catalogNamePredicate = MetadataProviderConditions.getCatalogNamePredicate(
         catalog != null ? UserProtos.LikeFilter.newBuilder().setPattern(catalog).build() : null);
-      Pattern schemaFilterPattern = schemaPattern != null ? Pattern.compile(RegexpUtil.sqlToRegexLike(schemaPattern)) :
+      final Pattern schemaFilterPattern = schemaPattern != null ? Pattern.compile(RegexpUtil.sqlToRegexLike(schemaPattern)) :
         Pattern.compile(".*");
 
-      VarCharVector catalogNameVector = (VarCharVector) root.getVector("catalog_name");
-      VarCharVector schemaNameVector = (VarCharVector) root.getVector("schema_name");
+      final VarCharVector catalogNameVector = (VarCharVector) root.getVector("catalog_name");
+      final VarCharVector schemaNameVector = (VarCharVector) root.getVector("schema_name");
 
       for (int i = 0; i < root.getRowCount(); i++) {
-        String catalogName = catalogNameVector.getObject(i).toString();
-        String schemaName = schemaNameVector.getObject(i).toString();
+        final String catalogName = catalogNameVector.getObject(i).toString();
+        final String schemaName = schemaNameVector.getObject(i).toString();
 
         Assert.assertTrue(catalogNamePredicate.test(catalogName));
         Assert.assertTrue(schemaFilterPattern.matcher(schemaName).matches());

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightServerWithBasicAuth.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightServerWithBasicAuth.java
@@ -16,11 +16,7 @@
 
 package com.dremio.service.flight;
 
-import java.nio.charset.StandardCharsets;
-
 import org.apache.arrow.flight.CallOption;
-import org.apache.arrow.flight.FlightDescriptor;
-import org.apache.arrow.flight.FlightInfo;
 import org.junit.BeforeClass;
 
 import com.dremio.service.flight.impl.FlightWorkManager;

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightServerWithTokenAuth.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightServerWithTokenAuth.java
@@ -16,11 +16,7 @@
 
 package com.dremio.service.flight;
 
-import java.nio.charset.StandardCharsets;
-
 import org.apache.arrow.flight.CallOption;
-import org.apache.arrow.flight.FlightDescriptor;
-import org.apache.arrow.flight.FlightInfo;
 import org.junit.BeforeClass;
 
 import com.dremio.service.flight.impl.FlightWorkManager;
@@ -46,12 +42,6 @@ public class TestFlightServerWithTokenAuth extends AbstractTestFlightServer {
   @Override
   CallOption[] getCallOptions() {
     final FlightClientUtils.FlightClientWrapper wrapper = getFlightClientWrapper();
-    return new CallOption[] { wrapper.getTokenCallOption() };
-  }
-
-  @Override
-  public FlightInfo getFlightInfo(String query) {
-    final FlightDescriptor command = FlightDescriptor.command(query.getBytes(StandardCharsets.UTF_8));
-    return getFlightClientWrapper().getClient().getInfo(command, getCallOptions());
+    return new CallOption[] {wrapper.getTokenCallOption()};
   }
 }

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithBasicAuth.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithBasicAuth.java
@@ -16,17 +16,22 @@
 
 package com.dremio.service.flight;
 
+import static com.dremio.service.flight.BaseFlightQueryTest.setupBaseFlightQueryTest;
+
 import org.apache.arrow.flight.CallOption;
 import org.junit.BeforeClass;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
 import com.dremio.service.flight.impl.FlightWorkManager;
 
 /**
  * Test FlightServer with basic authentication using FlightSql producer.
  */
-public class TestFlightSqlServerWithBasicAuth extends AbstractTestFlightSqlServer {
-  @BeforeClass
-  public static void setup() throws Exception {
+@RunWith(Enclosed.class)
+public class TestFlightSqlServerWithBasicAuth {
+
+  private static void setup() throws Exception {
     setupBaseFlightQueryTest(
       false,
       true,
@@ -35,13 +40,37 @@ public class TestFlightSqlServerWithBasicAuth extends AbstractTestFlightSqlServe
       DremioFlightService.FLIGHT_LEGACY_AUTH_MODE);
   }
 
-  @Override
-  protected String getAuthMode() {
-    return DremioFlightService.FLIGHT_LEGACY_AUTH_MODE;
+  public static class QueryExecutionTests extends AbstractTestFlightSqlServer {
+    public QueryExecutionTests(ExecutionMode executionMode) {
+      super(executionMode);
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+      TestFlightSqlServerWithBasicAuth.setup();
+    }
+
+    @Override
+    protected String getAuthMode() {
+      return DremioFlightService.FLIGHT_LEGACY_AUTH_MODE;
+    }
+
+    @Override
+    CallOption[] getCallOptions() {
+      return new CallOption[0];
+    }
   }
 
-  @Override
-  CallOption[] getCallOptions() {
-    return new CallOption[0];
+  public static class CatalogMethodsTests extends AbstractTestFlightSqlServerCatalogMethods {
+    @BeforeClass
+    public static void setup() throws Exception {
+      TestFlightSqlServerWithBasicAuth.setup();
+    }
+
+    @Override
+    CallOption[] getCallOptions() {
+      return new CallOption[0];
+    }
   }
+
 }

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithBasicAuth.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithBasicAuth.java
@@ -40,6 +40,9 @@ public class TestFlightSqlServerWithBasicAuth {
       DremioFlightService.FLIGHT_LEGACY_AUTH_MODE);
   }
 
+  /**
+   * Query execution tests.
+   */
   public static class QueryExecutionTests extends AbstractTestFlightSqlServer {
     public QueryExecutionTests(ExecutionMode executionMode) {
       super(executionMode);
@@ -61,6 +64,9 @@ public class TestFlightSqlServerWithBasicAuth {
     }
   }
 
+  /**
+   * Catalog methods tests.
+   */
   public static class CatalogMethodsTests extends AbstractTestFlightSqlServerCatalogMethods {
     @BeforeClass
     public static void setup() throws Exception {

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithTokenAuth.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithTokenAuth.java
@@ -39,6 +39,9 @@ public class TestFlightSqlServerWithTokenAuth {
       FlightWorkManager.RunQueryResponseHandlerFactory.DEFAULT);
   }
 
+  /**
+   * Query execution tests.
+   */
   public static class QueryExecutionTests extends AbstractTestFlightSqlServer {
     public QueryExecutionTests(ExecutionMode executionMode) {
       super(executionMode);
@@ -61,6 +64,9 @@ public class TestFlightSqlServerWithTokenAuth {
     }
   }
 
+  /**
+   * Catalog methods tests.
+   */
   public static class CatalogMethodsTests extends AbstractTestFlightSqlServerCatalogMethods {
     @BeforeClass
     public static void setup() throws Exception {

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithTokenAuth.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/TestFlightSqlServerWithTokenAuth.java
@@ -16,17 +16,22 @@
 
 package com.dremio.service.flight;
 
+import static com.dremio.service.flight.BaseFlightQueryTest.setupBaseFlightQueryTest;
+
 import org.apache.arrow.flight.CallOption;
 import org.junit.BeforeClass;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 
 import com.dremio.service.flight.impl.FlightWorkManager;
 
 /**
  * Test FlightServer with bearer token authentication using FlightSql producer.
  */
-public class TestFlightSqlServerWithTokenAuth extends AbstractTestFlightSqlServer {
-  @BeforeClass
-  public static void setup() throws Exception {
+@RunWith(Enclosed.class)
+public class TestFlightSqlServerWithTokenAuth {
+
+  private static void setup() throws Exception {
     setupBaseFlightQueryTest(
       false,
       true,
@@ -34,14 +39,38 @@ public class TestFlightSqlServerWithTokenAuth extends AbstractTestFlightSqlServe
       FlightWorkManager.RunQueryResponseHandlerFactory.DEFAULT);
   }
 
-  @Override
-  protected String getAuthMode() {
-    return DremioFlightService.FLIGHT_AUTH2_AUTH_MODE;
+  public static class QueryExecutionTests extends AbstractTestFlightSqlServer {
+    public QueryExecutionTests(ExecutionMode executionMode) {
+      super(executionMode);
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+      TestFlightSqlServerWithTokenAuth.setup();
+    }
+
+    @Override
+    protected String getAuthMode() {
+      return DremioFlightService.FLIGHT_AUTH2_AUTH_MODE;
+    }
+
+    @Override
+    CallOption[] getCallOptions() {
+      final FlightClientUtils.FlightClientWrapper wrapper = getFlightClientWrapper();
+      return new CallOption[] {wrapper.getTokenCallOption()};
+    }
   }
 
-  @Override
-  CallOption[] getCallOptions() {
-    final FlightClientUtils.FlightClientWrapper wrapper = getFlightClientWrapper();
-    return new CallOption[] {wrapper.getTokenCallOption()};
+  public static class CatalogMethodsTests extends AbstractTestFlightSqlServerCatalogMethods {
+    @BeforeClass
+    public static void setup() throws Exception {
+      TestFlightSqlServerWithTokenAuth.setup();
+    }
+
+    @Override
+    CallOption[] getCallOptions() {
+      final FlightClientUtils.FlightClientWrapper wrapper = getFlightClientWrapper();
+      return new CallOption[] {wrapper.getTokenCallOption()};
+    }
   }
 }

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/impl/TestFlightPreparedStatement.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/impl/TestFlightPreparedStatement.java
@@ -28,6 +28,7 @@ import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.FlightInfo;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.flight.sql.impl.FlightSql;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -42,6 +43,7 @@ import com.dremio.exec.proto.UserProtos.PreparedStatementHandle;
 import com.dremio.service.flight.TicketContent;
 import com.dremio.service.flight.protector.CancellableUserResponseHandler;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 
 import io.grpc.Status;
@@ -64,7 +66,6 @@ public class TestFlightPreparedStatement {
     .asRuntimeException();
 
   private static final String command = "command";
-  private static final FlightDescriptor flightDescriptor = FlightDescriptor.command(command.getBytes(StandardCharsets.UTF_8));
 
   private static final Schema schema = new Schema(Collections.singletonList(Field.nullable("test1", ArrowType.Bool.INSTANCE)));
   private static final PreparedStatementHandle preparedStatementHandle = PreparedStatementHandle
@@ -102,7 +103,7 @@ public class TestFlightPreparedStatement {
     thrown.expect(io.grpc.StatusRuntimeException.class);
     thrown.expectCause(isA(UserException.class));
 
-    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(flightDescriptor, command, mockHandler);
+    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(command, mockHandler);
 
     // Act
     flightPreparedStatement.getSchema();
@@ -116,7 +117,7 @@ public class TestFlightPreparedStatement {
     thrown.expect(io.grpc.StatusRuntimeException.class);
     thrown.expectCause(isA(UserException.class));
 
-    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(flightDescriptor, command, mockHandler);
+    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(command, mockHandler);
 
     // Act
     flightPreparedStatement.getSchema();
@@ -127,7 +128,7 @@ public class TestFlightPreparedStatement {
     // Arrange
     when(mockHandler.get()).thenReturn(response);
 
-    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(flightDescriptor, command, mockHandler);
+    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(command, mockHandler);
 
     // Act
     final Schema actual = flightPreparedStatement.getSchema();
@@ -144,7 +145,7 @@ public class TestFlightPreparedStatement {
     thrown.expect(io.grpc.StatusRuntimeException.class);
     thrown.expectCause(isA(UserException.class));
 
-    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(flightDescriptor, command, mockHandler);
+    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(command, mockHandler);
 
     // Act
     flightPreparedStatement.getFlightInfo(mockLocation);
@@ -158,7 +159,7 @@ public class TestFlightPreparedStatement {
     thrown.expect(io.grpc.StatusRuntimeException.class);
     thrown.expectCause(isA(UserException.class));
 
-    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(flightDescriptor, command, mockHandler);
+    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(command, mockHandler);
 
     // Act
     flightPreparedStatement.getFlightInfo(mockLocation);
@@ -168,15 +169,15 @@ public class TestFlightPreparedStatement {
   public void testGetFlightInfoSuccessful() {
     // Arrange
     when(mockHandler.get()).thenReturn(response);
-    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(flightDescriptor, command, mockHandler);
+    final FlightPreparedStatement flightPreparedStatement = new FlightPreparedStatement(command, mockHandler);
 
-    final TicketContent.PreparedStatementTicket preparedStatementTicketContent = TicketContent.PreparedStatementTicket.newBuilder()
-      .setQuery(command)
-      .setHandle(preparedStatementHandle)
+    final FlightSql.CommandPreparedStatementQuery command = FlightSql.CommandPreparedStatementQuery.newBuilder()
+      .setPreparedStatementHandle(preparedStatementHandle.toByteString())
       .build();
-
-    final Ticket ticket = new Ticket(preparedStatementTicketContent.toByteArray());
+    final FlightDescriptor flightDescriptor = FlightDescriptor.command(Any.pack(command).toByteArray());
+    final Ticket ticket = new Ticket(Any.pack(command).toByteArray());
     final FlightEndpoint flightEndpoint = new FlightEndpoint(ticket, mockLocation);
+
     final FlightInfo expected = new FlightInfo(schema, flightDescriptor, ImmutableList.of(flightEndpoint), -1, -1);
 
     // Act

--- a/services/arrow-flight/src/test/java/com/dremio/service/flight/impl/TestFlightPreparedStatement.java
+++ b/services/arrow-flight/src/test/java/com/dremio/service/flight/impl/TestFlightPreparedStatement.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import org.apache.arrow.flight.FlightDescriptor;
@@ -40,7 +39,6 @@ import org.junit.rules.ExpectedException;
 import com.dremio.common.exceptions.UserException;
 import com.dremio.exec.proto.UserProtos;
 import com.dremio.exec.proto.UserProtos.PreparedStatementHandle;
-import com.dremio.service.flight.TicketContent;
 import com.dremio.service.flight.protector.CancellableUserResponseHandler;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Any;


### PR DESCRIPTION
This implements `CommandStatementQuery` on DremioFlightProducer.

Other changes in this PR:
- Update with last version of `FlightSqlClient`
- Move unit tests of catalog functions and refactor top-level test classes to test both Statement and PreparedStatement query executions